### PR TITLE
[FEAT] 인증 메일 기능 구현 #19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,10 @@ dependencies {
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-    testImplementation 'org.projectlombok:lombok:1.18.22'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+
+	testImplementation 'org.projectlombok:lombok:1.18.22'
 	testImplementation 'org.projectlombok:lombok:1.18.22'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/plac/common/Constant.java
+++ b/src/main/java/com/plac/common/Constant.java
@@ -1,0 +1,21 @@
+package com.plac.common;
+
+public interface Constant {
+
+    String USER_ROLE = "USER";
+
+    String[] ALL_PERMIT_PATHS = new String[]{
+            "/api/users/one",
+            "/api/users/emails/availability",
+            "/api/login/**",
+            "/api/social-login",
+            "/api/social-login/**",
+            "/api/emails/send-verification-email",
+            "/api/emails/verify-code",
+    };
+
+    String[] USER_ROLE_PERMIT_PATHS = new String[]{
+            "/api/**",
+            "/api/test/**",
+    };
+}

--- a/src/main/java/com/plac/config/AsyncConfig.java
+++ b/src/main/java/com/plac/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.plac.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/plac/config/JpaConfig.java
+++ b/src/main/java/com/plac/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.plac.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/plac/config/SecurityConfig.java
+++ b/src/main/java/com/plac/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.plac.config;
 
+import com.plac.common.Constant;
 import com.plac.repository.RefreshTokenRepository;
 import com.plac.repository.UserRepository;
 import com.plac.security.auth.CustomUserDetailsService;
@@ -56,13 +57,9 @@ public class SecurityConfig {
 
         http
                 .authorizeRequests()
-                .antMatchers("/api/test/**")
-                .access("hasRole('ROLE_USER')")
-                .antMatchers("/api/user/one", "/api/login/**", "/api/social-login", "/api/social-login/**")
-                .permitAll()
-                .antMatchers("/api/**")
-                .access("hasRole('ROLE_USER')")
-                .anyRequest().permitAll();
+                .antMatchers(Constant.ALL_PERMIT_PATHS).permitAll()
+                .antMatchers(Constant.USER_ROLE_PERMIT_PATHS).hasRole(Constant.USER_ROLE)
+                .anyRequest().denyAll();
 
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         http.addFilterAfter(jwtAuthorizationFilter, JwtAuthenticationFilter.class);

--- a/src/main/java/com/plac/controller/EmailController.java
+++ b/src/main/java/com/plac/controller/EmailController.java
@@ -1,0 +1,46 @@
+package com.plac.controller;
+
+import com.plac.dto.request.email.EmailReqDto;
+import com.plac.dto.request.email.EmailVerifyReqDto;
+import com.plac.service.email.EmailVerificationService;
+import com.plac.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/emails")
+public class EmailController {
+
+    private final EmailVerificationService emailVerificationService;
+    private final UserService userService;
+
+    @PostMapping("/send-verification-email")
+    public ResponseEntity<Void> sendVerificationEmail(
+            @Valid @RequestBody EmailReqDto dto
+    ) {
+        String inputEmail = dto.getEmail();
+
+        userService.checkEmailAvailability(inputEmail);
+
+        emailVerificationService.sendSignupVerificationEmail(inputEmail);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<Void> verifyEmailVerificationCode(
+            @Valid @RequestBody EmailVerifyReqDto dto
+    ) {
+        emailVerificationService.verifySignupEmail(dto.getEmail(), dto.getCode());
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/plac/controller/UserController.java
+++ b/src/main/java/com/plac/controller/UserController.java
@@ -1,23 +1,22 @@
 package com.plac.controller;
 
+import com.plac.dto.request.email.EmailReqDto;
 import com.plac.dto.request.user.UserReqDto;
-import com.plac.dto.response.user.UserResDto;
 import com.plac.service.user.UserService;
 import com.plac.util.MessageUtil;
-import com.plac.util.SecurityContextHolderUtil;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/user")
+@RequestMapping("/api/users")
 public class UserController {
 
     private final UserService userService;
@@ -53,27 +52,14 @@ public class UserController {
         return MessageUtil.buildResponseEntity(HttpStatus.OK, "success");
     }
 
+    @GetMapping("/emails/availability")
+    public ResponseEntity<Void> checkEmailAvailability(
+            @Valid @RequestBody EmailReqDto dto
+    ) {
+        String inputEmail = dto.getEmail();
 
-    /**
-     * TEST URL : 테스트가 끝나면 필수적으로 지워야 함.
-     * */
-    @Operation(summary = "로그인 테스트 api", description = "로그인 상태에서, 해당 유저의 정보를 출력.")
-    @GetMapping("/test1")
-    public ResponseEntity<?> TestApi() throws Exception {
-        Long userId = SecurityContextHolderUtil.getUserId();
-        UserResDto userResDto = UserResDto.of(userService.findUser(userId));
+        userService.checkEmailAvailability(inputEmail);
 
-        return MessageUtil.buildResponseEntity(userResDto, HttpStatus.OK, "success");
+        return new ResponseEntity<>(HttpStatus.OK);
     }
-
-    @Operation(summary = "로그인 테스트 api", description = "로그인 상태에서, 등록된 모든 유저정보 출력")
-    @GetMapping("/test2")
-    public ResponseEntity<?> searchAll(){
-        List<UserResDto> result = userService.findAll();
-
-        return MessageUtil.buildResponseEntity(result, HttpStatus.OK, "success");
-    }
-
-    /*
-    * */
 }

--- a/src/main/java/com/plac/domain/AbstractTimeEntity.java
+++ b/src/main/java/com/plac/domain/AbstractTimeEntity.java
@@ -1,0 +1,26 @@
+package com.plac.domain;
+
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AbstractTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/plac/domain/EmailVerification.java
+++ b/src/main/java/com/plac/domain/EmailVerification.java
@@ -19,7 +19,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity(name = "email_verification")
-public class EmailVerification {
+public class EmailVerification extends AbstractTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/plac/domain/EmailVerification.java
+++ b/src/main/java/com/plac/domain/EmailVerification.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -73,17 +75,17 @@ public class EmailVerification extends AbstractTimeEntity {
         LocalDateTime current = LocalDateTime.now();
 
         if (checkedStatus) {
-            throw new IllegalStateException("이미 인증된 번호입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 인증된 번호입니다.");
         }
         if (expireAt.isBefore(current)) {
-            throw new IllegalStateException("인증 번호가 만료되었습니다.");
+            throw new ResponseStatusException(HttpStatus.GONE, "인증 번호가 만료되었습니다.");
         }
     }
 
     public void matchVerificationCode(int code) {
         int contentCode = Integer.valueOf(content);
         if (contentCode != code) {
-            throw new RuntimeException("인증 번호가 일치하지 않습니다.");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "인증 번호가 일치하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/plac/domain/EmailVerification.java
+++ b/src/main/java/com/plac/domain/EmailVerification.java
@@ -1,0 +1,89 @@
+package com.plac.domain;
+
+import com.plac.domain.mappedenum.EmailVerificationContentType;
+import com.plac.util.RandomGeneratorUtil;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "email_verification")
+public class EmailVerification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String receiptEmail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "content_type")
+    private EmailVerificationContentType contentType;
+
+    private String content;
+
+    private boolean checkedStatus;
+
+    private LocalDateTime expireAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    private Long userId;
+
+    public static EmailVerification createForSignup(String email, long expMinutes) {
+        String content = String.valueOf(RandomGeneratorUtil.generateRandomSixDigitNumber());
+        LocalDateTime expireAt = LocalDateTime.now().plusMinutes(expMinutes);
+
+        return EmailVerification.builder()
+                .receiptEmail(email)
+                .contentType(EmailVerificationContentType.SIGNUP)
+                .content(content)
+                .checkedStatus(false)
+                .expireAt(expireAt)
+                .build();
+    }
+
+    public void checkAndValidate() {
+        validateCanCheck();
+        check();
+    }
+
+    private void check() {
+        this.checkedStatus = true;
+    }
+
+    private void validateCanCheck() {
+        LocalDateTime current = LocalDateTime.now();
+
+        if (checkedStatus) {
+            throw new IllegalStateException("이미 인증된 번호입니다.");
+        }
+        if (expireAt.isBefore(current)) {
+            throw new IllegalStateException("인증 번호가 만료되었습니다.");
+        }
+    }
+
+    public void matchVerificationCode(int code) {
+        int contentCode = Integer.valueOf(content);
+        if (contentCode != code) {
+            throw new RuntimeException("인증 번호가 일치하지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/plac/domain/User.java
+++ b/src/main/java/com/plac/domain/User.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Builder
 @Entity
-@Table(name = "users")
+@Table(name = "user")
 public class User {
 
     @Id

--- a/src/main/java/com/plac/domain/User.java
+++ b/src/main/java/com/plac/domain/User.java
@@ -1,5 +1,6 @@
 package com.plac.domain;
 
+import com.plac.domain.mappedenum.UserStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +9,6 @@ import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.Type;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Getter
@@ -17,19 +17,16 @@ import java.util.UUID;
 @Builder
 @Entity
 @Table(name = "user")
-public class User {
+public class User extends AbstractTimeEntity {
 
+    @Column(name = "password", nullable = false)
+    String password;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
     private Long id;
-
     @Column(name = "username", nullable = false)
     private String username;
-
-    @Column(name = "password", nullable = false)
-    String password;
-
     @Column(name = "salt", nullable = true)
     @Type(type = "uuid-char")
     private UUID salt;
@@ -41,10 +38,10 @@ public class User {
     private String profileName;
 
     @Column(nullable = true)
-    private String profileImagePath;
+    private String profileImageUrl;
 
     @Column(nullable = true)
-    private String profileBirth;
+    private String profileBirthday;
 
     @Column(nullable = true)
     private int age;
@@ -55,11 +52,10 @@ public class User {
     @Column(nullable = true)
     private String phoneNumber;
 
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(nullable = true)
-    private LocalDateTime updatedAt;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    @Builder.Default
+    private UserStatus status = UserStatus.ACTIVE;
 
     @Comment("소셜 로그인시 갱신됨 (네이버, 카카오, 구글 중 하나)")
     @Column(name = "provider", nullable = true)
@@ -76,7 +72,7 @@ public class User {
         this.password = password;
     }
 
-    public String getUsername(){
+    public String getUsername() {
         return this.username;
     }
 
@@ -89,12 +85,12 @@ public class User {
                 ", salt=" + salt +
                 ", roles='" + roles + '\'' +
                 ", profileName='" + profileName + '\'' +
-                ", profileImagePath='" + profileImagePath + '\'' +
-                ", profileBirth='" + profileBirth + '\'' +
+                ", profileImagePath='" + profileImageUrl + '\'' +
+                ", profileBirth='" + profileBirthday + '\'' +
                 ", age=" + age +
                 ", phoneNumber='" + phoneNumber + '\'' +
-                ", createdAt=" + createdAt +
-                ", updatedAt=" + updatedAt +
+                ", createdAt=" + super.getCreatedAt() +
+                ", updatedAt=" + super.getUpdatedAt() +
                 ", provider='" + provider + '\'' +
                 '}';
     }

--- a/src/main/java/com/plac/domain/mappedenum/EmailVerificationContentType.java
+++ b/src/main/java/com/plac/domain/mappedenum/EmailVerificationContentType.java
@@ -1,0 +1,8 @@
+package com.plac.domain.mappedenum;
+
+import lombok.Getter;
+
+@Getter
+public enum EmailVerificationContentType {
+    SIGNUP, PASSWORD_RESET, EMAIL_REGISTRATION
+}

--- a/src/main/java/com/plac/domain/mappedenum/UserStatus.java
+++ b/src/main/java/com/plac/domain/mappedenum/UserStatus.java
@@ -1,0 +1,5 @@
+package com.plac.domain.mappedenum;
+
+public enum UserStatus {
+    PRE_VERIFIED,ACTIVE,INACTIVE,SUSPENDED,DELETED;
+}

--- a/src/main/java/com/plac/dto/request/email/EmailReqDto.java
+++ b/src/main/java/com/plac/dto/request/email/EmailReqDto.java
@@ -1,0 +1,16 @@
+package com.plac.dto.request.email;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+public class EmailReqDto {
+
+    @NotBlank(message = "이메일은 공백일 수 없습니다")
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    private String email;
+}

--- a/src/main/java/com/plac/dto/request/email/EmailVerifyReqDto.java
+++ b/src/main/java/com/plac/dto/request/email/EmailVerifyReqDto.java
@@ -1,0 +1,20 @@
+package com.plac.dto.request.email;
+
+import com.sun.istack.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Setter
+public class EmailVerifyReqDto {
+
+    @NotBlank(message = "이메일은 공백일 수 없습니다")
+    @Email(message = "유효한 이메일 형식이 아닙니다")
+    private String email;
+
+    @NotNull
+    private int code;
+}

--- a/src/main/java/com/plac/dto/response/user/UserResDto.java
+++ b/src/main/java/com/plac/dto/response/user/UserResDto.java
@@ -4,6 +4,7 @@ import com.plac.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+
 import java.time.LocalDateTime;
 
 @Getter
@@ -27,8 +28,8 @@ public class UserResDto {
                 .id(user.getId())
                 .username(user.getUsername())
                 .profile_name(user.getProfileName())
-                .profile_image_path(user.getProfileImagePath())
-                .profile_birth(user.getProfileBirth())
+                .profile_image_path(user.getProfileImageUrl())
+                .profile_birth(user.getProfileBirthday())
                 .age(user.getAge())
                 .gender(user.getGender())
                 .phoneNumber(user.getPhoneNumber())

--- a/src/main/java/com/plac/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/plac/repository/EmailVerificationRepository.java
@@ -1,0 +1,13 @@
+package com.plac.repository;
+
+import com.plac.domain.EmailVerification;
+import com.plac.domain.mappedenum.EmailVerificationContentType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+    Optional<EmailVerification> findTopByReceiptEmailAndContentTypeOrderByCreatedAtDesc(String receiptEmail, EmailVerificationContentType contentType);
+}

--- a/src/main/java/com/plac/service/email/EmailService.java
+++ b/src/main/java/com/plac/service/email/EmailService.java
@@ -1,0 +1,10 @@
+package com.plac.service.email;
+
+import org.springframework.scheduling.annotation.Async;
+
+public interface EmailService {
+
+    @Async
+    void sendSimpleMessage(
+            String to, String subject, String text);
+}

--- a/src/main/java/com/plac/service/email/EmailServiceImpl.java
+++ b/src/main/java/com/plac/service/email/EmailServiceImpl.java
@@ -3,9 +3,11 @@ package com.plac.service.email;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.mail.internet.MimeMessage;
 
@@ -30,7 +32,7 @@ public class EmailServiceImpl implements EmailService {
             helper.setText(text, true);
             emailSender.send(message);
         } catch (Exception e) {
-            log.error("Exception details: ", e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 발송에 실패했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/plac/service/email/EmailServiceImpl.java
+++ b/src/main/java/com/plac/service/email/EmailServiceImpl.java
@@ -1,0 +1,36 @@
+package com.plac.service.email;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Component;
+
+import javax.mail.internet.MimeMessage;
+
+@Component
+@Log4j2
+public class EmailServiceImpl implements EmailService {
+
+    @Autowired
+    private JavaMailSender emailSender;
+
+    @Value("${spring.mail.username}")
+    private String senderEmail;
+
+    public void sendSimpleMessage(String to, String subject, String text) {
+        MimeMessage message = emailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+            helper.setFrom(senderEmail);
+            helper.setTo(to);
+            helper.setSubject(subject);
+            helper.setText(text, true);
+            emailSender.send(message);
+        } catch (Exception e) {
+            log.error("Exception details: ", e);
+        }
+    }
+}

--- a/src/main/java/com/plac/service/email/EmailVerificationService.java
+++ b/src/main/java/com/plac/service/email/EmailVerificationService.java
@@ -5,7 +5,9 @@ import com.plac.domain.mappedenum.EmailVerificationContentType;
 import com.plac.repository.EmailVerificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 
@@ -39,7 +41,7 @@ public class EmailVerificationService {
 
     public void verifySignupEmail(String email, int verificationCode) {
         EmailVerification emailVerification = emailVerificationRepository.findTopByReceiptEmailAndContentTypeOrderByCreatedAtDesc(email, EmailVerificationContentType.SIGNUP)
-                .orElseThrow(() -> new RuntimeException("인증 번호가 없습니다. 재전송하세요."));
+                .orElseThrow(() ->new ResponseStatusException(HttpStatus.BAD_REQUEST, "인증 번호가 없습니다. 재전송하세요."));
 
         emailVerification.checkAndValidate();
         emailVerification.matchVerificationCode(verificationCode);
@@ -48,7 +50,7 @@ public class EmailVerificationService {
 
     public boolean isVerifiedEmail(String email) {
         EmailVerification emailVerification = emailVerificationRepository.findTopByReceiptEmailAndContentTypeOrderByCreatedAtDesc(email, EmailVerificationContentType.SIGNUP)
-                .orElseThrow(() -> new RuntimeException("이메일 인증이 필요합니다."));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일 인증이 필요합니다."));
 
         return emailVerification.isCheckedStatus() && emailVerification.getUpdatedAt().isBefore(LocalDateTime.now().plusMinutes(VERIFICATION_COMPLETION_EFFECTIVE_TIME));
     }

--- a/src/main/java/com/plac/service/email/EmailVerificationService.java
+++ b/src/main/java/com/plac/service/email/EmailVerificationService.java
@@ -1,0 +1,42 @@
+package com.plac.service.email;
+
+import com.plac.domain.EmailVerification;
+import com.plac.domain.mappedenum.EmailVerificationContentType;
+import com.plac.repository.EmailVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class EmailVerificationService {
+
+    private final EmailVerificationRepository emailVerificationRepository;
+    private final EmailService emailService;
+
+    @Value("${plac.email.expire-minutes.signup}")
+    private final long SIGN_UP_EMAIL_EXP_MINUTES = 3L;
+
+    public void sendSignupVerificationEmail(String email) {
+        EmailVerification emailVerification = EmailVerification.createForSignup(email, SIGN_UP_EMAIL_EXP_MINUTES);
+        emailVerificationRepository.save(emailVerification);
+        emailService.sendSimpleMessage(
+                emailVerification.getReceiptEmail(),
+                "[PLAC] 가입 인증 번호 안내",
+                "<html>\n" +
+                        "<body>\n" +
+                        "    <h3>안녕하세요. 인증 번호 확인 후 이메일 인증을 완료해 주세요.</h3>\n" +
+                        "    <p>인증 번호 : " + emailVerification.getContent() + "</p>\n" +
+                        "</body>" +
+                        "</html>"
+        );
+    }
+
+    public void verifySignupEmail(String email, int verificationCode) {
+        EmailVerification emailVerification = emailVerificationRepository.findTopByReceiptEmailAndContentTypeOrderByCreatedAtDesc(email, EmailVerificationContentType.SIGNUP)
+                .orElseThrow(() -> new RuntimeException("인증 번호가 없습니다. 재전송하세요."));
+
+        emailVerification.checkAndValidate();
+        emailVerification.matchVerificationCode(verificationCode);
+    }
+}

--- a/src/main/java/com/plac/service/social_login/SocialLoginServiceImpl.java
+++ b/src/main/java/com/plac/service/social_login/SocialLoginServiceImpl.java
@@ -91,12 +91,11 @@ public class SocialLoginServiceImpl implements SocialLoginService{
                 .password(encodedPassword)
                 .roles("ROLE_USER")
                 .provider(oauth2UserInfo.getProvider())
-                .profileImagePath(oauth2UserInfo.getProfileImagePath())
+                .profileImageUrl(oauth2UserInfo.getProfileImagePath())
                 .profileName(oauth2UserInfo.getProfileName())
-                .profileBirth(oauth2UserInfo.getProfileBirth())
+                .profileBirthday(oauth2UserInfo.getProfileBirth())
                 .phoneNumber(oauth2UserInfo.getPhoneNumber())
                 .gender(oauth2UserInfo.getGender())
-                .createdAt(LocalDateTime.now())
                 .age(oauth2UserInfo.getAge())
                 .build();
     }

--- a/src/main/java/com/plac/service/user/UserService.java
+++ b/src/main/java/com/plac/service/user/UserService.java
@@ -7,9 +7,15 @@ import com.plac.dto.response.user.UserResDto;
 import java.util.List;
 
 public interface UserService {
-    public UserResDto signUp(UserReqDto.CreateUser reqDto);
-    public User findUser(Long userId);
-    public void deleteUser();
-    public void deleteUser(Long userId);
-    public List<UserResDto> findAll();
+    UserResDto signUp(UserReqDto.CreateUser reqDto);
+
+    User findUser(Long userId);
+
+    void deleteUser();
+
+    void deleteUser(Long userId);
+
+    List<UserResDto> findAll();
+
+    void checkEmailAvailability(String email);
 }

--- a/src/main/java/com/plac/service/user/UserServiceImpl.java
+++ b/src/main/java/com/plac/service/user/UserServiceImpl.java
@@ -11,8 +11,10 @@ import com.plac.repository.UserRepository;
 import com.plac.service.password_checker.PasswordChecker;
 import com.plac.util.SecurityContextHolderUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.Optional;
@@ -104,7 +106,7 @@ public class UserServiceImpl implements UserService {
         Optional<User> optionalUser = userRepository.findByUsername(email);
 
         if (optionalUser.isPresent()) {
-            throw new RuntimeException("이미 존재하는 이메일입니다.");
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다.");
         }
     }
 }

--- a/src/main/java/com/plac/service/user/UserServiceImpl.java
+++ b/src/main/java/com/plac/service/user/UserServiceImpl.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,14 +21,14 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService{
+public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordChecker passwordChecker;
     private final RefreshTokenRepository refreshTokenRepository;
     private final BCryptPasswordEncoder encoder;
 
     @Override
-    public UserResDto signUp(UserReqDto.CreateUser reqDto){
+    public UserResDto signUp(UserReqDto.CreateUser reqDto) {
         checkDuplUser(reqDto);
         passwordChecker.checkWeakPassword(reqDto.getPassword());
 
@@ -81,14 +80,14 @@ public class UserServiceImpl implements UserService{
     private void checkDuplUser(UserReqDto.CreateUser reqDto) {
         final Optional<User> user = userRepository.findByUsername(reqDto.getUsername());
 
-        if(user.isPresent()){
+        if (user.isPresent()) {
             throw new DuplUsernameException("이미 존재하는 username(이메일)입니다.");
         }
     }
 
     private User createNormalUserInfo(UserReqDto.CreateUser reqDto, String password) {
         UUID salt = UUID.randomUUID();
-        String encodedPassword = encoder.encode(password + salt.toString());
+        String encodedPassword = encoder.encode(password + salt);
 
         User user = User.builder()
                 .username(reqDto.getUsername())
@@ -97,10 +96,15 @@ public class UserServiceImpl implements UserService{
                 .provider("normal")
                 .roles("ROLE_USER")
                 .profileName(reqDto.getProfileName())
-                .createdAt(LocalDateTime.now())
                 .build();
         return user;
     }
 
+    public void checkEmailAvailability(String email) {
+        Optional<User> optionalUser = userRepository.findByUsername(email);
 
+        if (optionalUser.isPresent()) {
+            throw new RuntimeException("이미 존재하는 이메일입니다.");
+        }
+    }
 }

--- a/src/main/java/com/plac/util/RandomGeneratorUtil.java
+++ b/src/main/java/com/plac/util/RandomGeneratorUtil.java
@@ -1,0 +1,14 @@
+package com.plac.util;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+
+@Component
+public class RandomGeneratorUtil {
+
+    public static int generateRandomSixDigitNumber() {
+        SecureRandom secureRandom = new SecureRandom();
+        return secureRandom.nextInt(900000) + 10000;
+    }
+}

--- a/src/test/java/com/plac/service/email/EmailVerificationServiceTest.java
+++ b/src/test/java/com/plac/service/email/EmailVerificationServiceTest.java
@@ -1,0 +1,75 @@
+package com.plac.service.email;
+
+import com.plac.domain.EmailVerification;
+import com.plac.domain.User;
+import com.plac.repository.EmailVerificationRepository;
+import com.plac.repository.UserRepository;
+import com.plac.util.RandomGeneratorUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class EmailVerificationServiceTest {
+
+    @Autowired
+    private EmailVerificationRepository emailVerificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EmailVerificationService emailVerificationService;
+
+    @MockBean
+    private RandomGeneratorUtil randomGeneratorUtil;
+
+    public EmailVerificationServiceTest() {
+    }
+
+    @BeforeEach
+    public void setUp() {
+        User user = User.builder()
+                .username("ejcong99@naver.com")
+                .password("password")
+                .provider("normal")
+                .roles("ROLE_USER")
+                .createdAt(LocalDateTime.now())
+                .build();
+        userRepository.save(user); // userId = 1L;
+    }
+
+    @Test
+    public void sendSignupVerificationEmailTest() {
+        assertDoesNotThrow(() -> emailVerificationService.sendSignupVerificationEmail("ejcong99@naver.com"));
+    }
+
+    @Test
+    public void checkSignupEmailTest() {
+        String receiptEmail = "ejcong99@naver.com";
+        long expMinutes = 3L;
+
+        EmailVerification emailVerification1 = EmailVerification.createForSignup(receiptEmail, expMinutes);
+        EmailVerification emailVerification2 = EmailVerification.createForSignup(receiptEmail, expMinutes);
+        EmailVerification emailVerification3 = EmailVerification.createForSignup(receiptEmail, expMinutes);
+
+        int verificationCode = Integer.valueOf(emailVerification3.getContent());
+
+        emailVerificationRepository.save(emailVerification1);
+        emailVerificationRepository.save(emailVerification2);
+        emailVerificationRepository.save(emailVerification3);
+
+        assertDoesNotThrow(() -> emailVerificationService.verifySignupEmail(receiptEmail, Integer.valueOf(verificationCode)));
+    }
+}


### PR DESCRIPTION
### 이슈
#19 

### 주요 기능 
- 이메일 중복 확인
- 인증 메일 전송/재전송
- 인증 코드를 통한 메일 인증

### 추가 변경 사항
- SecurityConfig의 접근 경로 Constant로 분리
- 엔티티의 createdAt, updatedAt 필드를 처리하는 AbstractTimeEntity 추가, JPA 설정 추가
- 이메일 전송 비동기 처리, Async 설정 추가

### 테스트
- EmailVerificationServiceTest
  - 이메일 전송 기능 테스트
  - 인증번호 검증 기능 테스트